### PR TITLE
Fix releasing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,6 @@ jobs:
                path: build-reports.zip
 
    macos:
-      needs: version
       if: github.repository == 'Kantis/ks3'
       runs-on: macos-11
       strategy:
@@ -115,7 +114,6 @@ jobs:
                path: build-reports.zip
 
    windows:
-      needs: version
       if: github.repository == 'Kantis/ks3'
       runs-on: windows-latest
       steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,24 +20,8 @@ permissions:
    contents: read
 
 jobs:
-   version:
-      runs-on: ubuntu-latest
-      outputs:
-         version: ${{ steps.semver.outputs.version }}
-      steps:
-         -  name: Checkout the repo
-            uses: actions/checkout@v3
-            with:
-               fetch-depth: 0
-
-         -  name: Calculate version
-            id: semver
-            uses: paulhatch/semantic-version@v4.0.2
-            with:
-               format: "${major}.${minor}.${patch}-SNAPSHOT"
 
    linux:
-      needs: version
       if: github.repository == 'Kantis/ks3'
       runs-on: ubuntu-latest
       strategy:
@@ -67,9 +51,6 @@ jobs:
 
          -  name: Run tests
             run: ./gradlew ${{ matrix.target }} --scan --stacktrace --info
-
-         -  name: Publish
-            run: ./gradlew -Pversion=${{ needs.version.outputs.version }} publish
 
          -  name: Bundle the build report
             if: failure()
@@ -122,9 +103,6 @@ jobs:
          -  name: Run tests
             run: ./gradlew ${{ matrix.target }} --scan --stacktrace --info
 
-         -  name: Publish
-            run: ./gradlew -Pversion=${{ needs.version.outputs.version }} publish
-
          -  name: Bundle the build report
             if: failure()
             run: find . -type d -name 'reports' | zip -@ -r build-reports.zip
@@ -161,9 +139,6 @@ jobs:
          -  name: Run tests
             run: ./gradlew mingwX64Test --scan --stacktrace --info
 
-         -  name: Publish
-            run: ./gradlew -Pversion=${{ needs.version.outputs.version }} publish
-
          -  name: Bundle the build report
             if: failure()
             run: find . -type d -name 'reports' | zip -@ -r build-reports.zip
@@ -180,7 +155,3 @@ env:
    ORG_GRADLE_PROJECT_ks3_enableKotlinMultiplatformJvm: true
    ORG_GRADLE_PROJECT_ks3_enableKotlinMultiplatformJs: true
    ORG_GRADLE_PROJECT_ks3_enableKotlinMultiplatformNative: true
-   ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-   ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-   OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-   OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
                key: ${{ runner.os }}-kotlin-konan
 
          -  name: Publish Sonatype
-            run: ./gradlew -Pversion=${{ needs.version.outputs.version }} publishAllPublicationsToSonatypeReleaseRepository
+            run: ./gradlew publishAllPublicationsToSonatypeReleaseRepository -Pversion=${{ needs.version.outputs.version }} --stacktrace --info
 
 
 env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,9 +2,61 @@ on:
    push:
       tags:
          - v**
+      branches:
+         - main
+         - release/*
+   workflow_dispatch:
+
 
 jobs:
+   version:
+      runs-on: ubuntu-latest
+      outputs:
+         version: ${{ steps.semver.outputs.version }}
+      steps:
+         -  name: Checkout the repo
+            uses: actions/checkout@v3
+            with:
+               fetch-depth: 0
+
+         -  name: Calculate version
+            id: semver
+            uses: paulhatch/semantic-version@v4.0.2
+            with:
+               format: "${major}.${minor}.${patch}-SNAPSHOT"
+
    release:
+      needs: version
       steps:
          -  name: Release
             run: echo "Releasing ${{ }}"
+
+         -  name: Checkout the repo
+            uses: actions/checkout@v3
+
+         -  name: Setup JDK
+            uses: actions/setup-java@v3
+            with:
+               distribution: 'temurin'
+               java-version: '11'
+
+         -  uses: gradle/gradle-build-action@v2
+
+         -  id: cache-kotlin-konan
+            uses: actions/cache@v3
+            with:
+               path: ~/.konan
+               key: ${{ runner.os }}-kotlin-konan
+
+         -  name: Publish Sonatype
+            run: ./gradlew -Pversion=${{ needs.version.outputs.version }} publishAllPublicationsToSonatypeReleaseRepository
+
+
+env:
+   ORG_GRADLE_PROJECT_ks3_enableKotlinMultiplatformJvm: true
+   ORG_GRADLE_PROJECT_ks3_enableKotlinMultiplatformJs: true
+   ORG_GRADLE_PROJECT_ks3_enableKotlinMultiplatformNative: true
+   ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+   ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+   ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
+   ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,5 @@
+name: release
+
 on:
    push:
       tags:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,8 +28,6 @@ jobs:
    release:
       needs: version
       steps:
-         -  name: Release
-            run: echo "Releasing ${{ }}"
 
          -  name: Checkout the repo
             uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
 
          -  name: Calculate version
             id: semver
-            uses: paulhatch/semantic-version@v4.0.2
+            uses: paulhatch/semantic-version@v4
             with:
                format: "${major}.${minor}.${patch}-SNAPSHOT"
 


### PR DESCRIPTION
* split up release from CI (we probably don't want to release on every PR, [it might not even be possible](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#accessing-secrets))
* get Sonatype user/pass using Gradle property format: `ORG_GRADLE_PROJECT_ossrhUsername`