### PR TITLE
fix Gradle signing

### DIFF
--- a/build-logic/src/main/kotlin/ks3/conventions/lang/kotlin-multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/ks3/conventions/lang/kotlin-multiplatform.gradle.kts
@@ -21,7 +21,7 @@ fun kotlin(configure: KotlinMultiplatformExtension.() -> Unit) = extensions.conf
 
 kotlin {
    jvmToolchain {
-      (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(ks3BuildLogicSettings.jvmTarget.get()))
+      languageVersion.set(JavaLanguageVersion.of(ks3BuildLogicSettings.jvmTarget.get()))
    }
 
    targets.configureEach {

--- a/build-logic/src/main/kotlin/ks3/conventions/publishing/accessors.kt
+++ b/build-logic/src/main/kotlin/ks3/conventions/publishing/accessors.kt
@@ -1,0 +1,15 @@
+package ks3.conventions.publishing
+
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.plugins.signing.SigningExtension
+
+// Hacks, because IntelliJ is refusing to load the generated Gradle Kotlin DSL accessors.
+// These aren't necessary for building, only so auto-complete works.
+
+internal val Project.signing get() = extensions.getByType<SigningExtension>()
+internal fun Project.signing(action: SigningExtension.() -> Unit) = extensions.configure(action)
+internal val Project.publishing get() = extensions.getByType<PublishingExtension>()
+internal fun Project.publishing(action: PublishingExtension.() -> Unit) = extensions.configure(action)


### PR DESCRIPTION
Some lovely hacks for getting the signing plugin to work, copied from another of my projects.

https://github.com/adamko-dev/kotlinx-serialization-typescript-generator/blob/2914dd6256600671f37583c5371759cc8ec27393/buildSrc/src/main/kotlin/buildsrc/convention/maven-publish.gradle.kts

To test, run `./gradlew publishAllPublicationsToMavenProjectLocalRepository` and check `./build/maven-project-local` for `.asc` files.

![image](https://user-images.githubusercontent.com/897017/198101960-29979694-89a3-4ac2-9ad4-ef20d1a58681.png)

