### PR TITLE
prototype for BigDecimal and BigInteger serializers

### DIFF
--- a/build-logic/repositories.gradle.kts
+++ b/build-logic/repositories.gradle.kts
@@ -67,6 +67,16 @@ dependencyResolutionManagement {
       sonatypeSnapshots()
       google()
       gradlePluginPortal() // tvOS builds need to be able to fetch a Kotlin Gradle plugin
+
+      // I hacked together a deploy script for the latest KxS version - this should be removed ASAP
+      // 1.5.0 is required for BigDecimal JSON encoding support
+      // ks3 probably shouldn't be published while this dependency exists
+      maven("https://raw.githubusercontent.com/aSemy/kotlinx.serialization/artifacts/m2/") {
+         mavenContent {
+            includeGroup("org.jetbrains.kotlinx")
+            snapshotsOnly()
+         }
+      }
    }
 
    pluginManagement {

--- a/build-logic/repositories.gradle.kts
+++ b/build-logic/repositories.gradle.kts
@@ -67,16 +67,6 @@ dependencyResolutionManagement {
       sonatypeSnapshots()
       google()
       gradlePluginPortal() // tvOS builds need to be able to fetch a Kotlin Gradle plugin
-
-      // I hacked together a deploy script for the latest KxS version - this should be removed ASAP
-      // 1.5.0 is required for BigDecimal JSON encoding support
-      // ks3 probably shouldn't be published while this dependency exists
-      maven("https://raw.githubusercontent.com/aSemy/kotlinx.serialization/artifacts/m2/") {
-         mavenContent {
-            includeGroup("org.jetbrains.kotlinx")
-            snapshotsOnly()
-         }
-      }
    }
 
    pluginManagement {

--- a/build-logic/src/main/kotlin/ks3/conventions/lang/kotlin-multiplatform-base.gradle.kts
+++ b/build-logic/src/main/kotlin/ks3/conventions/lang/kotlin-multiplatform-base.gradle.kts
@@ -55,6 +55,7 @@ kotlin {
       languageSettings {
          languageVersion = ks3Settings.kotlinTarget.get()
          apiVersion = ks3Settings.kotlinTarget.get()
+         optIn("kotlin.RequiresOptIn")
       }
    }
 }

--- a/doc/jdk.md
+++ b/doc/jdk.md
@@ -14,9 +14,19 @@
 
 ## `java.io`
 
-| Type | Serializer         | Example                 |
-|------|--------------------|-------------------------|
-| File | FilePathSerializer | `"/home/emil/file.txt"` |
+| Type | Serializer         | Typealias    | Example                 |
+|------|--------------------|--------------|-------------------------|
+| File | FilePathSerializer | FileAsString | `"/home/emil/file.txt"` |
+
+## `java.math`
+
+| Type       | Serializer                   | Typealias               | Example                    |
+|------------|------------------------------|-------------------------|----------------------------|
+| BigDecimal | BigDecimalAsStringSerializer | BigDecimalAsString      | `"3.12345678901234567890"` |
+| BigDecimal | BigDecimalAsDouble           | BigDecimalAsDouble      | `3.1234567890123457`       |
+| BigDecimal | BigDecimalAsJsonLiteral      | BigDecimalAsJsonLiteral | `3.12345678901234567890`   |
+| BigInteger | BigIntegerAsString           | BigIntegerAsString      | `"9223372036854775808"`    |
+| BigInteger | BigIntegerAsJsonLiteral      | BigIntegerAsJsonLiteral | `9223372036854775808`      |
 
 ## `java.net`
 

--- a/ks3-jdk/api/ks3-jdk.api
+++ b/ks3-jdk/api/ks3-jdk.api
@@ -16,8 +16,8 @@ public final class io/ks3/java/math/BigDecimalAsDoubleSerializer : kotlinx/seria
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/math/BigDecimal;)V
 }
 
-public final class io/ks3/java/math/BigDecimalAsJsonLiteralSerializer : kotlinx/serialization/KSerializer {
-	public static final field INSTANCE Lio/ks3/java/math/BigDecimalAsJsonLiteralSerializer;
+public final class io/ks3/java/math/BigDecimalAsJsonNumberSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lio/ks3/java/math/BigDecimalAsJsonNumberSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/math/BigDecimal;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;

--- a/ks3-jdk/api/ks3-jdk.api
+++ b/ks3-jdk/api/ks3-jdk.api
@@ -7,6 +7,51 @@ public final class io/ks3/java/io/FilePathSerializer : kotlinx/serialization/KSe
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 }
 
+public final class io/ks3/java/math/BigDecimalAsDoubleSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lio/ks3/java/math/BigDecimalAsDoubleSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/math/BigDecimal;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/math/BigDecimal;)V
+}
+
+public final class io/ks3/java/math/BigDecimalAsJsonLiteralSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lio/ks3/java/math/BigDecimalAsJsonLiteralSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/math/BigDecimal;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/math/BigDecimal;)V
+}
+
+public final class io/ks3/java/math/BigDecimalAsStringSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lio/ks3/java/math/BigDecimalAsStringSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/math/BigDecimal;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/math/BigDecimal;)V
+}
+
+public final class io/ks3/java/math/BigIntegerAsJsonLiteralSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lio/ks3/java/math/BigIntegerAsJsonLiteralSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/math/BigInteger;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/math/BigInteger;)V
+}
+
+public final class io/ks3/java/math/BigIntegerAsStringSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lio/ks3/java/math/BigIntegerAsStringSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/math/BigInteger;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/math/BigInteger;)V
+}
+
 public final class io/ks3/java/net/UriSerializer : kotlinx/serialization/KSerializer {
 	public static final field INSTANCE Lio/ks3/java/net/UriSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;

--- a/ks3-jdk/build.gradle.kts
+++ b/ks3-jdk/build.gradle.kts
@@ -32,6 +32,7 @@ kotlin {
             implementation(projects.ks3Core)
             implementation(projects.ks3Standard)
             implementation(libs.kotlinxSerialization.core)
+            implementation(libs.kotlinxSerialization.json)
          }
       }
 

--- a/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigDecimalSerializers.kt
+++ b/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigDecimalSerializers.kt
@@ -1,8 +1,12 @@
 package io.ks3.java.math
 
+import io.ks3.standard.stringSerializer
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
@@ -11,8 +15,45 @@ import kotlinx.serialization.json.JsonUnquotedLiteral
 import kotlinx.serialization.json.jsonPrimitive
 import java.math.BigDecimal
 
-object BigNumericSerializer : KSerializer<BigDecimal> {
+/**
+ * Encodes a [BigDecimal] as a string, preserving the full precision of the number. Wraps the number in quotes.
+ */
+typealias BigDecimalAsString = @Serializable(with = BigDecimalAsStringSerializer::class) BigDecimal
 
+/**
+ * Encodes a [BigDecimal] to it's closest double representation. [Double] have limited precision, so the number might not be
+ * exactly the same as the original [BigDecimal].
+ */
+typealias BigDecimalAsDouble = @Serializable(with = BigDecimalAsDoubleSerializer::class) BigDecimal
+
+/**
+ * Encodes a [BigDecimal] as an unquoted JSON literal, preserving the full precision of the number while being encoded as a number.
+ *
+ * Note that this typealias is primarily meant for JSON, other formats will have the [BigDecimal] encoded as a string.
+ */
+@ExperimentalSerializationApi
+typealias BigDecimalAsHighPrecisionNumber = @Serializable(with = BigDecimalAsHighPrecisionNumberSerializer::class) BigDecimal
+
+
+object BigDecimalAsStringSerializer : KSerializer<BigDecimal> by stringSerializer(::BigDecimal, BigDecimal::toPlainString)
+object BigDecimalAsDoubleSerializer : KSerializer<BigDecimal> {
+   override val descriptor = PrimitiveSerialDescriptor("java.math.BigDecimal", PrimitiveKind.DOUBLE)
+
+   override fun deserialize(decoder: Decoder): BigDecimal =
+      BigDecimal(decoder.decodeDouble())
+
+   override fun serialize(encoder: Encoder, value: BigDecimal) {
+      encoder.encodeDouble(value.toDouble())
+   }
+}
+
+/**
+ * Encodes a [BigDecimal] as an unquoted JSON literal, preserving the full precision of the number while being encoded as a number.
+ *
+ * Note that this serializer is primarily meant for JSON, other formats will have the [BigDecimal] encoded as a string.
+ */
+@ExperimentalSerializationApi
+object BigDecimalAsHighPrecisionNumberSerializer : KSerializer<BigDecimal> {
    override val descriptor = PrimitiveSerialDescriptor("java.math.BigDecimal", PrimitiveKind.DOUBLE)
 
    override fun deserialize(decoder: Decoder): BigDecimal {

--- a/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigDecimalSerializers.kt
+++ b/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigDecimalSerializers.kt
@@ -32,7 +32,7 @@ typealias BigDecimalAsDouble = @Serializable(with = BigDecimalAsDoubleSerializer
  * Note that this typealias is primarily meant for JSON, other formats will have the [BigDecimal] encoded as a string.
  */
 @ExperimentalSerializationApi
-typealias BigDecimalAsJsonLiteral = @Serializable(with = BigDecimalAsJsonLiteralSerializer::class) BigDecimal
+typealias BigDecimalAsJsonNumber = @Serializable(with = BigDecimalAsJsonNumberSerializer::class) BigDecimal
 
 
 object BigDecimalAsStringSerializer : KSerializer<BigDecimal> by stringSerializer(::BigDecimal, BigDecimal::toPlainString)
@@ -44,8 +44,8 @@ object BigDecimalAsDoubleSerializer : KSerializer<BigDecimal> by doubleSerialize
  * Note that this serializer is primarily meant for JSON, other formats will have the [BigDecimal] encoded as a string.
  */
 @ExperimentalSerializationApi
-object BigDecimalAsJsonLiteralSerializer : KSerializer<BigDecimal> {
-   override val descriptor = PrimitiveSerialDescriptor("java.math.BigDecimal", PrimitiveKind.DOUBLE)
+object BigDecimalAsJsonNumberSerializer : KSerializer<BigDecimal> {
+   override val descriptor = PrimitiveSerialDescriptor("java.math.BigDecimal", PrimitiveKind.STRING)
 
    override fun deserialize(decoder: Decoder): BigDecimal {
       return if (decoder is JsonDecoder) {

--- a/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigDecimalSerializers.kt
+++ b/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigDecimalSerializers.kt
@@ -1,12 +1,12 @@
 package io.ks3.java.math
 
+import io.ks3.standard.doubleSerializer
 import io.ks3.standard.stringSerializer
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
@@ -21,7 +21,7 @@ import java.math.BigDecimal
 typealias BigDecimalAsString = @Serializable(with = BigDecimalAsStringSerializer::class) BigDecimal
 
 /**
- * Encodes a [BigDecimal] to it's closest double representation. [Double] have limited precision, so the number might not be
+ * Encodes a [BigDecimal] to it's double representation. [Double] have limited precision, so the number might not be
  * exactly the same as the original [BigDecimal].
  */
 typealias BigDecimalAsDouble = @Serializable(with = BigDecimalAsDoubleSerializer::class) BigDecimal
@@ -32,20 +32,11 @@ typealias BigDecimalAsDouble = @Serializable(with = BigDecimalAsDoubleSerializer
  * Note that this typealias is primarily meant for JSON, other formats will have the [BigDecimal] encoded as a string.
  */
 @ExperimentalSerializationApi
-typealias BigDecimalAsHighPrecisionNumber = @Serializable(with = BigDecimalAsHighPrecisionNumberSerializer::class) BigDecimal
+typealias BigDecimalAsJsonLiteral = @Serializable(with = BigDecimalAsJsonLiteralSerializer::class) BigDecimal
 
 
 object BigDecimalAsStringSerializer : KSerializer<BigDecimal> by stringSerializer(::BigDecimal, BigDecimal::toPlainString)
-object BigDecimalAsDoubleSerializer : KSerializer<BigDecimal> {
-   override val descriptor = PrimitiveSerialDescriptor("java.math.BigDecimal", PrimitiveKind.DOUBLE)
-
-   override fun deserialize(decoder: Decoder): BigDecimal =
-      BigDecimal(decoder.decodeDouble())
-
-   override fun serialize(encoder: Encoder, value: BigDecimal) {
-      encoder.encodeDouble(value.toDouble())
-   }
-}
+object BigDecimalAsDoubleSerializer : KSerializer<BigDecimal> by doubleSerializer({ it.toString().toBigDecimal() }, BigDecimal::toDouble)
 
 /**
  * Encodes a [BigDecimal] as an unquoted JSON literal, preserving the full precision of the number while being encoded as a number.
@@ -53,7 +44,7 @@ object BigDecimalAsDoubleSerializer : KSerializer<BigDecimal> {
  * Note that this serializer is primarily meant for JSON, other formats will have the [BigDecimal] encoded as a string.
  */
 @ExperimentalSerializationApi
-object BigDecimalAsHighPrecisionNumberSerializer : KSerializer<BigDecimal> {
+object BigDecimalAsJsonLiteralSerializer : KSerializer<BigDecimal> {
    override val descriptor = PrimitiveSerialDescriptor("java.math.BigDecimal", PrimitiveKind.DOUBLE)
 
    override fun deserialize(decoder: Decoder): BigDecimal {

--- a/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigDecimalSerializers.kt
+++ b/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigDecimalSerializers.kt
@@ -39,7 +39,7 @@ object BigDecimalAsStringSerializer : KSerializer<BigDecimal> by stringSerialize
 object BigDecimalAsDoubleSerializer : KSerializer<BigDecimal> by doubleSerializer({ it.toString().toBigDecimal() }, BigDecimal::toDouble)
 
 /**
- * Encodes a [BigDecimal] as an unquoted JSON literal, preserving the full precision of the number while being encoded as a number.
+ * Encodes a [BigDecimal] as an exact numeric value, preserving the full precision of the number.
  *
  * Note that this serializer is primarily meant for JSON, other formats will have the [BigDecimal] encoded as a string.
  */

--- a/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigDecimalSerializers.kt
+++ b/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigDecimalSerializers.kt
@@ -1,3 +1,35 @@
 package io.ks3.java.math
 
-// TODO
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonUnquotedLiteral
+import kotlinx.serialization.json.jsonPrimitive
+import java.math.BigDecimal
+
+object BigNumericSerializer : KSerializer<BigDecimal> {
+
+   override val descriptor = PrimitiveSerialDescriptor("java.math.BigDecimal", PrimitiveKind.DOUBLE)
+
+   override fun deserialize(decoder: Decoder): BigDecimal {
+      return if (decoder is JsonDecoder) {
+         BigDecimal(decoder.decodeJsonElement().jsonPrimitive.content)
+      } else {
+         BigDecimal(decoder.decodeString())
+      }
+   }
+
+   override fun serialize(encoder: Encoder, value: BigDecimal) {
+      val bdString = value.toPlainString()
+
+      if (encoder is JsonEncoder) {
+         encoder.encodeJsonElement(JsonUnquotedLiteral(bdString))
+      } else {
+         encoder.encodeString(bdString)
+      }
+   }
+}

--- a/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigIntegerSerializers.kt
+++ b/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigIntegerSerializers.kt
@@ -1,3 +1,37 @@
 package io.ks3.java.math
 
-// TODO
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonUnquotedLiteral
+import kotlinx.serialization.json.jsonPrimitive
+import java.math.BigInteger
+
+object BigIntegerSerializer : KSerializer<BigInteger> {
+
+   override val descriptor = PrimitiveSerialDescriptor("java.math.BigDecimal", PrimitiveKind.DOUBLE)
+
+   override fun deserialize(decoder: Decoder): BigInteger {
+      return if (decoder is JsonDecoder) {
+         BigInteger(decoder.decodeJsonElement().jsonPrimitive.content)
+      } else {
+         BigInteger(decoder.decodeString())
+      }
+   }
+
+   @OptIn(ExperimentalSerializationApi::class)
+   override fun serialize(encoder: Encoder, value: BigInteger) {
+      val bdString = value.toString()
+
+      if (encoder is JsonEncoder) {
+         encoder.encodeJsonElement(JsonUnquotedLiteral(bdString))
+      } else {
+         encoder.encodeString(bdString)
+      }
+   }
+}

--- a/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigIntegerSerializers.kt
+++ b/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigIntegerSerializers.kt
@@ -1,7 +1,10 @@
 package io.ks3.java.math
 
+import io.ks3.standard.doubleSerializer
+import io.ks3.standard.stringSerializer
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
@@ -10,11 +13,35 @@ import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonUnquotedLiteral
 import kotlinx.serialization.json.jsonPrimitive
+import java.math.BigDecimal
 import java.math.BigInteger
 
-object BigIntegerSerializer : KSerializer<BigInteger> {
 
-   override val descriptor = PrimitiveSerialDescriptor("java.math.BigDecimal", PrimitiveKind.DOUBLE)
+/**
+ * Encodes a [BigDecimal] as a string, preserving the full precision of the number. Wraps the number in quotes.
+ */
+typealias BigIntegerAsString = @Serializable(with = BigIntegerAsStringSerializer::class) BigInteger
+
+/**
+ * Encodes a [BigInteger] as an unquoted JSON literal, preserving the full precision of the number while being encoded as a number.
+ *
+ * Note that this typealias is primarily meant for JSON, other formats will have the [BigInteger] encoded as a string.
+ */
+@ExperimentalSerializationApi
+typealias BigIntegerAsJsonLiteral = @Serializable(with = BigIntegerAsJsonLiteralSerializer::class) BigInteger
+
+
+object BigIntegerAsStringSerializer : KSerializer<BigInteger> by stringSerializer(::BigInteger, BigInteger::toString)
+
+/**
+ * Encodes a [BigInteger] as an unquoted JSON literal, preserving the full precision of the number while being encoded as a number.
+ *
+ * Note that this serializer is primarily meant for JSON, other formats will have the [BigInteger] encoded as a string.
+ */
+@ExperimentalSerializationApi
+object BigIntegerAsJsonLiteralSerializer : KSerializer<BigInteger> {
+
+   override val descriptor = PrimitiveSerialDescriptor("java.math.BigInteger", PrimitiveKind.DOUBLE)
 
    override fun deserialize(decoder: Decoder): BigInteger {
       return if (decoder is JsonDecoder) {
@@ -24,7 +51,6 @@ object BigIntegerSerializer : KSerializer<BigInteger> {
       }
    }
 
-   @OptIn(ExperimentalSerializationApi::class)
    override fun serialize(encoder: Encoder, value: BigInteger) {
       val bdString = value.toString()
 

--- a/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigIntegerSerializers.kt
+++ b/ks3-jdk/src/jvmMain/kotlin/io/ks3/java/math/BigIntegerSerializers.kt
@@ -34,7 +34,7 @@ typealias BigIntegerAsJsonLiteral = @Serializable(with = BigIntegerAsJsonLiteral
 object BigIntegerAsStringSerializer : KSerializer<BigInteger> by stringSerializer(::BigInteger, BigInteger::toString)
 
 /**
- * Encodes a [BigInteger] as an unquoted JSON literal, preserving the full precision of the number while being encoded as a number.
+ * Encodes a [BigInteger] as an exact numeric value, preserving the full precision of the number.
  *
  * Note that this serializer is primarily meant for JSON, other formats will have the [BigInteger] encoded as a string.
  */

--- a/ks3-jdk/src/jvmTest/kotlin/io/ks3/java/math/BigDecimalSerializerTests.kt
+++ b/ks3-jdk/src/jvmTest/kotlin/io/ks3/java/math/BigDecimalSerializerTests.kt
@@ -1,0 +1,46 @@
+package io.ks3.java.math
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.property.exhaustive.exhaustive
+import io.ks3.test.generateSerializerTests
+import kotlinx.serialization.ExperimentalSerializationApi
+import java.math.BigDecimal
+
+@OptIn(ExperimentalSerializationApi::class)
+class BigDecimalSerializerTests : FunSpec(
+   {
+      val someNumbers = listOf(
+         "0",
+         "-1E307",
+         "-1E-307",
+         "1.234349584529824359834295834958345892374892173498721349872398457234985798234758927349872341908273978174239823475982743982734988",
+         "982137498243758927439872398472983479827345982459824375982173948721398479817223987129483745782347823461982379812739817239873450.1",
+      ).map(::BigDecimal)
+         .map(BigDecimal::toPlainString) // Get rid of scientific notation
+         .map(::BigDecimal)
+
+      include(
+         generateSerializerTests(
+            BigDecimalAsStringSerializer,
+            someNumbers.exhaustive(),
+            { "BigDecimalAsStringSerializer performs round-trip serialization" },
+         ),
+      )
+
+      include(
+         generateSerializerTests(
+            BigDecimalAsHighPrecisionNumberSerializer,
+            someNumbers.exhaustive(),
+            { "BigDecimalAsHighPrecisionNumberSerializer performs round-trip serialization" },
+         ),
+      )
+
+      include(
+         generateSerializerTests(
+            BigDecimalAsDoubleSerializer,
+            someNumbers.exhaustive(),
+            { "BigDecimalAsHighPrecisionNumberSerializer performs round-trip serialization" },
+         ),
+      )
+   },
+)

--- a/ks3-jdk/src/jvmTest/kotlin/io/ks3/java/math/BigDecimalSerializerTests.kt
+++ b/ks3-jdk/src/jvmTest/kotlin/io/ks3/java/math/BigDecimalSerializerTests.kt
@@ -33,7 +33,7 @@ class BigDecimalSerializerTests : FunSpec(
 
       include(
          generateSerializerTests(
-            BigDecimalAsJsonLiteralSerializer,
+            BigDecimalAsJsonNumberSerializer,
             Arb.bigDecimal().withEdgecases(someNumbers),
             { "BigDecimalAsHighPrecisionNumberSerializer performs round-trip serialization" },
          ),

--- a/ks3-jdk/src/jvmTest/kotlin/io/ks3/java/math/BigDecimalSerializerTests.kt
+++ b/ks3-jdk/src/jvmTest/kotlin/io/ks3/java/math/BigDecimalSerializerTests.kt
@@ -1,7 +1,11 @@
 package io.ks3.java.math
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.property.exhaustive.exhaustive
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bigDecimal
+import io.kotest.property.arbitrary.double
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.withEdgecases
 import io.ks3.test.generateSerializerTests
 import kotlinx.serialization.ExperimentalSerializationApi
 import java.math.BigDecimal
@@ -22,15 +26,15 @@ class BigDecimalSerializerTests : FunSpec(
       include(
          generateSerializerTests(
             BigDecimalAsStringSerializer,
-            someNumbers.exhaustive(),
+            Arb.bigDecimal().withEdgecases(someNumbers),
             { "BigDecimalAsStringSerializer performs round-trip serialization" },
          ),
       )
 
       include(
          generateSerializerTests(
-            BigDecimalAsHighPrecisionNumberSerializer,
-            someNumbers.exhaustive(),
+            BigDecimalAsJsonLiteralSerializer,
+            Arb.bigDecimal().withEdgecases(someNumbers),
             { "BigDecimalAsHighPrecisionNumberSerializer performs round-trip serialization" },
          ),
       )
@@ -38,8 +42,10 @@ class BigDecimalSerializerTests : FunSpec(
       include(
          generateSerializerTests(
             BigDecimalAsDoubleSerializer,
-            someNumbers.exhaustive(),
-            { "BigDecimalAsHighPrecisionNumberSerializer performs round-trip serialization" },
+            Arb.double()
+               .withEdgecases(emptyList()) // get rid of NaN and Infinity
+               .map { BigDecimal(it.toString()) },
+            { "BigDecimalAsDoubleSerializer performs round-trip serialization" },
          ),
       )
    },

--- a/ks3-jdk/src/jvmTest/kotlin/io/ks3/java/math/BigIntegerSerializerTests.kt
+++ b/ks3-jdk/src/jvmTest/kotlin/io/ks3/java/math/BigIntegerSerializerTests.kt
@@ -1,0 +1,30 @@
+package io.ks3.java.math
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bigInt
+import io.ks3.test.generateSerializerTests
+import kotlinx.serialization.ExperimentalSerializationApi
+
+@OptIn(ExperimentalSerializationApi::class)
+class BigIntegerSerializerTests : FunSpec(
+   {
+
+      include(
+         generateSerializerTests(
+            BigIntegerAsStringSerializer,
+            Arb.bigInt(maxNumBits = 4096),
+            { "BigIntegerAsStringSerializer performs round-trip serialization" },
+         ),
+      )
+
+      include(
+         generateSerializerTests(
+            BigIntegerAsJsonLiteralSerializer,
+            Arb.bigInt(maxNumBits = 4096),
+            { "BigIntegerAsJsonLiteralSerializer performs round-trip serialization" },
+         ),
+      )
+
+   },
+)

--- a/ks3-standard/src/commonMain/kotlin/io/ks3/standard/DoubleSerializer.kt
+++ b/ks3-standard/src/commonMain/kotlin/io/ks3/standard/DoubleSerializer.kt
@@ -1,0 +1,21 @@
+package io.ks3.standard
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+inline fun <reified T> doubleSerializer(
+   crossinline decode: (Double) -> T,
+   crossinline encode: (T) -> Double,
+   nameOverride: String? = null,
+): KSerializer<T> = object : KSerializer<T> {
+   override val descriptor = PrimitiveSerialDescriptor(nameOverride ?: T::class.simpleName!!, PrimitiveKind.LONG)
+
+   override fun deserialize(decoder: Decoder) =
+      decode(decoder.decodeDouble())
+
+   override fun serialize(encoder: Encoder, value: T) =
+      encoder.encodeDouble(encode(value))
+}

--- a/ks3-standard/src/commonMain/kotlin/io/ks3/standard/DoubleSerializer.kt
+++ b/ks3-standard/src/commonMain/kotlin/io/ks3/standard/DoubleSerializer.kt
@@ -11,7 +11,7 @@ inline fun <reified T> doubleSerializer(
    crossinline encode: (T) -> Double,
    nameOverride: String? = null,
 ): KSerializer<T> = object : KSerializer<T> {
-   override val descriptor = PrimitiveSerialDescriptor(nameOverride ?: T::class.simpleName!!, PrimitiveKind.LONG)
+   override val descriptor = PrimitiveSerialDescriptor(nameOverride ?: T::class.simpleName!!, PrimitiveKind.DOUBLE)
 
    override fun deserialize(decoder: Decoder) =
       decode(decoder.decodeDouble())


### PR DESCRIPTION
A quick demo of BigDecimal and BigInteger serializers, based on a custom publication of a KxS snapshot release.

I hacked together a build&deploy script for the latest KxS version, since Jetbrains don't publish snapshot versions.

KxS 1.5.0 is required for BigDecimal JSON encoding support

ks3 probably shouldn't be published while this dependency exists