### PR TITLE
Adding typeOmittingTransformer

### DIFF
--- a/doc/standard.md
+++ b/doc/standard.md
@@ -17,3 +17,10 @@ object ShapeSerializer : KSerializer<Shape> by enumAsOrdinalSerializer()
 
 println(Json.encodeToString(ShapeSerializer, Shape.CIRCLE)) // "1"
 ```
+
+### TypeOmittingTransformer
+
+A function that generates a JsonTransformingSerializer that removes class discriminators.
+
+Useful when you serialize a sealed class hierarchy and don't want to include the class discriminator ("type" property, by default)
+in the JSON.

--- a/ks3-standard/src/commonMain/kotlin/io/ks3/standard/TypeOmittingTransformer.kt
+++ b/ks3-standard/src/commonMain/kotlin/io/ks3/standard/TypeOmittingTransformer.kt
@@ -12,16 +12,18 @@ import kotlinx.serialization.serializer
  *
  * This is useful when you want to serialize a sealed class hierarchy to JSON without including the type discriminator.
  *
- * @param classDiscriminatorProperty The name of the property that is used as the type discriminator. Defaults to "type".
+ * ⚠️Warning: Using a custom class discriminator will make this transformer silently fail‼️
+ *
+ * ⚠️Warning: JSON produced by this serializer cannot be deserialized back using the default serializer.
  */
-inline fun <reified T : Any> typeOmittingTransformer(classDiscriminatorProperty: String = "type") =
+inline fun <reified T : Any> typeOmittingTransformer() =
    object : JsonTransformingSerializer<T>(serializer()) {
       override fun transformSerialize(element: JsonElement): JsonElement =
          when (element) {
             is JsonObject ->
                buildJsonObject {
                   element.jsonObject.forEach { (key, value) ->
-                     if (key != classDiscriminatorProperty) put(key, value)
+                     if (key != "type") put(key, value)
                   }
                }
 

--- a/ks3-standard/src/commonMain/kotlin/io/ks3/standard/TypeOmittingTransformer.kt
+++ b/ks3-standard/src/commonMain/kotlin/io/ks3/standard/TypeOmittingTransformer.kt
@@ -1,0 +1,30 @@
+package io.ks3.standard
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonTransformingSerializer
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.serializer
+
+/**
+ * A serializer that omits the type discriminator when serializing with polymorphic serialization.
+ *
+ * This is useful when you want to serialize a sealed class hierarchy to JSON without including the type discriminator.
+ *
+ * @param classDiscriminatorProperty The name of the property that is used as the type discriminator. Defaults to "type".
+ */
+inline fun <reified T : Any> typeOmittingTransformer(classDiscriminatorProperty: String = "type") =
+   object : JsonTransformingSerializer<T>(serializer()) {
+      override fun transformSerialize(element: JsonElement): JsonElement =
+         when (element) {
+            is JsonObject ->
+               buildJsonObject {
+                  element.jsonObject.forEach { (key, value) ->
+                     if (key != classDiscriminatorProperty) put(key, value)
+                  }
+               }
+
+            else -> element
+         }
+   }

--- a/ks3-standard/src/commonTest/kotlin/io/ks3/standard/PolymorphicSerializationWithoutDiscriminatorsTest.kt
+++ b/ks3-standard/src/commonTest/kotlin/io/ks3/standard/PolymorphicSerializationWithoutDiscriminatorsTest.kt
@@ -1,0 +1,32 @@
+package io.ks3.standard
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+class PolymorphicSerializationWithoutDiscriminatorsTest : DescribeSpec(
+   {
+      val fooWithoutTypeSerializer = typeOmittingTransformer<Foo>()
+      val json = Json
+
+      describe("PolymorphicSerializationWithoutDiscriminatorsTest") {
+         it("should do something") {
+            json.encodeToString(
+               ListSerializer(fooWithoutTypeSerializer),
+               listOf(Foo.Bar("bar"), Foo.Baz(1)),
+            ) shouldBe """[{"bar":"bar"},{"baz":1}]"""
+         }
+      }
+   },
+) {
+   @Serializable
+   sealed class Foo {
+      @Serializable
+      data class Bar(val bar: String) : Foo()
+
+      @Serializable
+      data class Baz(val baz: Int) : Foo()
+   }
+}

--- a/ks3-standard/src/commonTest/kotlin/io/ks3/standard/PolymorphicSerializationWithoutDiscriminatorsTest.kt
+++ b/ks3-standard/src/commonTest/kotlin/io/ks3/standard/PolymorphicSerializationWithoutDiscriminatorsTest.kt
@@ -1,23 +1,21 @@
 package io.ks3.standard
 
-import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 
-class PolymorphicSerializationWithoutDiscriminatorsTest : DescribeSpec(
+class PolymorphicSerializationWithoutDiscriminatorsTest : StringSpec(
    {
       val fooWithoutTypeSerializer = typeOmittingTransformer<Foo>()
       val json = Json
 
-      describe("PolymorphicSerializationWithoutDiscriminatorsTest") {
-         it("should do something") {
-            json.encodeToString(
-               ListSerializer(fooWithoutTypeSerializer),
-               listOf(Foo.Bar("bar"), Foo.Baz(1)),
-            ) shouldBe """[{"bar":"bar"},{"baz":1}]"""
-         }
+      "should omit type when serializing" {
+         json.encodeToString(
+            ListSerializer(fooWithoutTypeSerializer),
+            listOf(Foo.Bar("bar"), Foo.Baz(1)),
+         ) shouldBe """[{"bar":"bar"},{"baz":1}]"""
       }
    },
 ) {

--- a/ks3-standard/src/commonTest/kotlin/io/ks3/standard/TypeOmittingTransformerTests.kt
+++ b/ks3-standard/src/commonTest/kotlin/io/ks3/standard/TypeOmittingTransformerTests.kt
@@ -6,13 +6,12 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 
-class PolymorphicSerializationWithoutDiscriminatorsTest : StringSpec(
+class TypeOmittingTransformerTests : StringSpec(
    {
       val fooWithoutTypeSerializer = typeOmittingTransformer<Foo>()
-      val json = Json
 
       "should omit type when serializing" {
-         json.encodeToString(
+         Json.encodeToString(
             ListSerializer(fooWithoutTypeSerializer),
             listOf(Foo.Bar("bar"), Foo.Baz(1)),
          ) shouldBe """[{"bar":"bar"},{"baz":1}]"""


### PR DESCRIPTION
Adding a utility function for deriving a `JsonTransformingSerializer` which can be used to eliminate the classDiscriminator when using polymorphic serialization.